### PR TITLE
Update python and workflow dependencies and versions

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1.6.0
+        uses: dependabot/fetch-metadata@v2.3.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4

--- a/graph_tutorial/requirements.txt
+++ b/graph_tutorial/requirements.txt
@@ -1,4 +1,5 @@
-Django==4.2.7
-msal==1.31.1
+Django==5.2;python_version>"3.9"
+Django==4.2.20;python_version<="3.9"
+msal==1.32.3
 python-dateutil==2.9.0.post0
 PyYAML==6.0.2


### PR DESCRIPTION
Hi :wave:

I noticed that there is an issue that dependabot cannot merge new django version, because python 3.9 is deprected starting django >=5.0, so I fixed the code.

Also I updated the matrix of python versions and requirements.txt, so it can be installed for python 3.9.

Let me know what do you think.